### PR TITLE
style: make symbols for event status more coherent

### DIFF
--- a/src/Resources/contao/files/theme-sac-pilatus/scss/components/_mod_calendar.scss
+++ b/src/Resources/contao/files/theme-sac-pilatus/scss/components/_mod_calendar.scss
@@ -154,7 +154,7 @@
   }
 
   .event-state-icon.event_status_2:before {
-    content: "\f2f8";
+    content: "\f056";
     color: $red;
   }
 
@@ -184,7 +184,7 @@
   }
 
   .event-state-icon.event_status_8:before {
-    content: "\f28d";
+    content: "\f28b";
     color: $red;
   }
 


### PR DESCRIPTION
suggestions: red pause symbol for event status 8 and red - symbol for status 2

circle (f111), ! (f06a), i (f05a), ? (f059), x (f057), - (f056), + (f055), pause (f28b), stopp (f28d), play (f144), ban (f05e), dot (f192) [https://fontawesome.com/v5/cheatsheet]