### PR TITLE
fest: add teaser after header in news page

### DIFF
--- a/src/Resources/contao/templates/theme-sac-pilatus/news_full.html5
+++ b/src/Resources/contao/templates/theme-sac-pilatus/news_full.html5
@@ -1,6 +1,7 @@
 <div class="layout_full block<?= $this->class ?>" itemscope itemtype="http://schema.org/Article">
 
   <h1 class="ce_headline mt-0" itemprop="name"><?= $this->newsHeadline ?></h1>
+  <strong><?= $this->teaser ?></strong>
   <?php if ($this->hasMetaFields): ?>
   <p class="info"><time datetime="<?= $this->datetime ?>" itemprop="datePublished"><?= $this->date ?></time> <?= $this->author ?> <?= $this->commentCount ?></p>
   <?php endif; ?>


### PR DESCRIPTION
Add teaser text in detailed news page as well and not only in  news card preview.