### PR TITLE
feature/navbar-level2-hover

### DIFF
--- a/symlink_stuff/files/theme-sac-pilatus/scss/components/_navbar.scss
+++ b/symlink_stuff/files/theme-sac-pilatus/scss/components/_navbar.scss
@@ -221,7 +221,7 @@ $color-level-2-hover: $dark;
               }
             }
 
-            > li:hover {
+            > li.page-container:hover {
               > a, > strong, > a > span {
                 color: $color-level-2 !important;
               }


### PR DESCRIPTION
fix: hover effect for level 2 links (with black text color) to visualize a link properly

See issue https://github.com/jonasmueller1/sac-pilatus-website/issues/25

Root cause:
Hover effect for level 2 was already defined

```
            > li > a > span:hover, > li > a > strong:hover {
              color: $color-level-2-hover !important;
            }
```

but overloaded with this:
```
            > li:hover {
              > a, > strong, > a > span {
                color: $color-level-2 !important;
              }
            }
```

@markocupic Thanks for your review!
