### PR TITLE
feature/navbar-level-2-icon

### DIFF
--- a/symlink_stuff/files/theme-sac-pilatus/scss/components/_navbar.scss
+++ b/symlink_stuff/files/theme-sac-pilatus/scss/components/_navbar.scss
@@ -204,7 +204,7 @@ $color-level-2-hover: $dark;
                 @include transition(color);
                 display: block;
                 margin-bottom: 0.5rem;
-                @include icon-before("\f138");
+                @include icon-before("\f138"); // circle-right
                 text-decoration: none !important;
 
                 &:before {
@@ -220,6 +220,10 @@ $color-level-2-hover: $dark;
 
               > strong {
                 border-bottom: 1px solid $color-level-2-active;
+              }
+
+              > a, > strong, > span {
+                @include icon-before("\f13a"); // circle-down
               }
             }
 


### PR DESCRIPTION
- feat: change icon to circle down for navbar level 2 elements without urls

Proposal for level 2 items in navbar WITHOUT urls (a.k.a. not clickable --> `li.page-container`):

![grafik](https://github.com/markocupic/contao-theme-sac-pilatus/assets/99007003/97d51c6b-d518-46e0-a9b8-ee59b4ab6314)

-->  behavior with icon arrow down would be similar like level 1.

No changes for level 2 items WITH urls (a.k.a clickable):

![grafik](https://github.com/markocupic/contao-theme-sac-pilatus/assets/99007003/5286011c-9105-4ac1-85ef-d49514fb2d32)

@markocupic What do you think about this proposal? Thanks.