### PR TITLE
feature/link-color-sidebar-nav

### DIFF
--- a/symlink_stuff/files/theme-sac-pilatus/scss/components/_sidebar-and-navigation.scss
+++ b/symlink_stuff/files/theme-sac-pilatus/scss/components/_sidebar-and-navigation.scss
@@ -4,6 +4,7 @@ $nav-close-btn-color: #ccc;
 //$nav-bg-hover-color: $accent-color;
 
 $nav-font-color: #222;
+$nav-link-color: $blue;
 $nav-bg-color: #fff;
 //$nav-font-color: #333;
 /* Dropdown - main navigation header */
@@ -180,6 +181,27 @@ body.sidebar-open {
     ul {
       display: none;
     }
+  }
+
+  // Link color for non-clickable items for all levels
+  .sidebar-navigation ul.level_1 > li.page-container > a {
+    color: $nav-font-color !important;
+  }
+  .sidebar-navigation ul.level_2 > li.page-container > a {
+    color: $nav-font-color !important;
+  }
+  .sidebar-navigation ul.level_3 > li.page-container > a {
+    color: $nav-font-color !important;
+  }
+  // Link color for clickable items for all levels
+  .sidebar-navigation ul.level_1 > li > a {
+    color: $nav-link-color !important;
+  }
+  .sidebar-navigation ul.level_2 > li > a {
+    color: $nav-link-color !important;
+  }
+  .sidebar-navigation ul.level_3 > li > a {
+    color: $nav-link-color !important;
   }
 
   // Iconfont for level_1


### PR DESCRIPTION
feat: distinguish menu item color for clickable links (blue) and non-clickable links (black)

See new blue color for truly links in sidebar navigation:
![Screenshot 2023-08-06 212330](https://github.com/markocupic/contao-theme-sac-pilatus/assets/99007003/6b4be32f-45f5-4457-9410-341ca5b46a4c)

@markocupic What is your opinion for this pull request for the navigation menu on mobile devices? 
Thank you for reviewing :-)